### PR TITLE
Add F# developer system prompt (#17)

### DIFF
--- a/system-prompts/fsharp-developer.md
+++ b/system-prompts/fsharp-developer.md
@@ -258,9 +258,9 @@ let ``serialization round-trips`` (order: Order) =
 **Wrapping mutable/exception-throwing C# APIs:**
 ```fsharp
 // Wrap at the boundary; F# code never sees exceptions or nulls
-let fetchUser (id: UserId) : Result<User, DbError> =
+let fetchUser (UserId id) : Result<User, DbError> =
     try
-        let raw = csharpRepository.GetById(UserId.value id)  // can throw, can return null
+        let raw = csharpRepository.GetById(id)  // can throw, can return null
         raw
         |> Option.ofObj
         |> Option.map User.fromRaw


### PR DESCRIPTION
## Summary
- Adds `system-prompts/fsharp-developer.md` — a composable system prompt for an F# developer persona
- Persona directives written as imperatives covering immutability, railway-oriented programming (`Result<'T, 'E>`), and type-driven design
- 8 skill @ references; domain expertise covers type system, functional patterns, `.fsproj` file ordering, FsCheck property-based testing, tooling, and C# interop boundaries
- Mandatory verification checklist at end of file

## Test plan
- [ ] File follows composable system prompt pattern (frontmatter, imperatives, skills, domain, checklist)
- [ ] Shortcut `fsh` is unique across system-prompts/
- [ ] No content duplicated from referenced skill files
- [ ] All directives are imperatives

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)