### PR TITLE
Use of 'shortcut' name as well as number when choosing persona/model.

### DIFF
--- a/claude-launcher/claude-launcher.py
+++ b/claude-launcher/claude-launcher.py
@@ -362,9 +362,9 @@ def interactive_select(personas: Dict[str, Path]) -> Tuple[Path, str]:
                     selected_persona = personas[persona_list[idx]]
                     break
                 else:
-                    print(f"Invalid selection. Enter 1-{len(persona_list)} or a shortcut.")
+                    print(f"Invalid selection. Try again.")
             except ValueError:
-                print(f"Invalid input. Enter a number or shortcut (e.g. tdd, opt).")
+                print(f"Invalid input. Try again.")
 
     # Step 2: Select model
     model_list = list(MODELS.keys())
@@ -408,9 +408,9 @@ def interactive_select(personas: Dict[str, Path]) -> Tuple[Path, str]:
                     selected_model = model_list[idx]
                     break
                 else:
-                    print(f"Invalid selection. Enter 1-{len(model_list)} or a shortcut.")
+                    print(f"Invalid selection. Try again.")
             except ValueError:
-                print(f"Invalid input. Enter a number or shortcut (e.g. opus, sonn, haik).")
+                print(f"Invalid input. Try again.")
 
     return selected_persona, selected_model
 

--- a/claude-launcher/claude-launcher.py
+++ b/claude-launcher/claude-launcher.py
@@ -345,20 +345,26 @@ def interactive_select(personas: Dict[str, Path]) -> Tuple[Path, str]:
             print(f"  {i}) {shortcut:<4} → {name}")
 
         while True:
-            try:
-                choice = input("\nEnter number: ").strip()
-                if choice.lower() == 'q':
-                    print("Cancelled")
-                    sys.exit(0)
+            choice = input("\nEnter number or shortcut: ").strip()
+            if choice.lower() == 'q':
+                print("Cancelled")
+                sys.exit(0)
 
+            # Try shortcut match first
+            if choice in persona_list:
+                selected_persona = personas[choice]
+                break
+
+            # Try numeric index
+            try:
                 idx = int(choice) - 1
                 if 0 <= idx < len(persona_list):
                     selected_persona = personas[persona_list[idx]]
                     break
                 else:
-                    print("Invalid selection. Try again.")
+                    print(f"Invalid selection. Enter 1-{len(persona_list)} or a shortcut.")
             except ValueError:
-                print("Invalid input. Try again.")
+                print(f"Invalid input. Enter a number or shortcut (e.g. tdd, opt).")
 
     # Step 2: Select model
     model_list = list(MODELS.keys())
@@ -385,20 +391,26 @@ def interactive_select(personas: Dict[str, Path]) -> Tuple[Path, str]:
 
         selected_model = None
         while True:
-            try:
-                choice = input("\nEnter number: ").strip()
-                if choice.lower() == 'q':
-                    print("Cancelled")
-                    sys.exit(0)
+            choice = input("\nEnter number or shortcut: ").strip()
+            if choice.lower() == 'q':
+                print("Cancelled")
+                sys.exit(0)
 
+            # Try shortcut match first
+            if choice in model_list:
+                selected_model = choice
+                break
+
+            # Try numeric index
+            try:
                 idx = int(choice) - 1
                 if 0 <= idx < len(model_list):
                     selected_model = model_list[idx]
                     break
                 else:
-                    print("Invalid selection. Try again.")
+                    print(f"Invalid selection. Enter 1-{len(model_list)} or a shortcut.")
             except ValueError:
-                print("Invalid input. Try again.")
+                print(f"Invalid input. Enter a number or shortcut (e.g. opus, sonn, haik).")
 
     return selected_persona, selected_model
 

--- a/claude-launcher/claude-launcher.py
+++ b/claude-launcher/claude-launcher.py
@@ -11,6 +11,7 @@ Features:
 - Team support: declarative teams via teams/*/team.yaml
 - Worktree passthrough: -w / --worktree [name]
 - Sandbox mode: --sandbox [repo-path] (runs via docker sandbox)
+- Claude params: --claude-params / -cp "<flags>" (extra flags forwarded to claude)
 """
 
 import json
@@ -18,6 +19,7 @@ import os
 import sys
 import subprocess
 import re
+import shlex
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
 
@@ -420,8 +422,9 @@ def extract_passthrough_flags(args: list) -> Tuple[list, list, Optional[str]]:
     Extract Claude Code flags that should be passed through unchanged.
 
     Currently supports:
-    - -w / --worktree [name]  (name is optional)
-    - --sandbox               (sandbox mode: uses cwd, auto-adds --worktree)
+    - -w / --worktree [name]         (name is optional)
+    - --sandbox                       (sandbox mode: uses cwd, auto-adds --worktree)
+    - --claude-params "<flags>"       (extra flags passed directly to claude, e.g. "--teammate-mode tmux")
 
     Returns:
         (remaining_args, passthrough_flags, sandbox_repo) where:
@@ -454,6 +457,20 @@ def extract_passthrough_flags(args: list) -> Tuple[list, list, Optional[str]]:
             passthrough.append("--worktree")
             if name:
                 passthrough.append(name)
+            i += 1
+            continue
+
+        if arg in ("--claude-params", "-cp"):
+            if i + 1 >= len(args):
+                print(f"✗ ERROR: --claude-params requires a value (e.g. --claude-params \"--teammate-mode tmux\")", file=sys.stderr)
+                sys.exit(1)
+            i += 1
+            try:
+                extra = shlex.split(args[i])
+            except ValueError as e:
+                print(f"✗ ERROR: Could not parse --claude-params value: {e}", file=sys.stderr)
+                sys.exit(1)
+            passthrough.extend(extra)
             i += 1
             continue
 


### PR DESCRIPTION
Minor amendment to allow the input of the shortcut as well as the number when selecting persona/model option.

# Rationale
* A number of times when wanting to browse the options for personas available, I launch `cl` and look through the options - and when I find the one I want, I actually end up typing the shortcut, like `tdd` instead of `9` which is the numbered option.
Although the numbered option is conventional...I don't think I'm the only one who would have made this mistake and therefore amending to allow.

